### PR TITLE
Migrate SegmentedControl to hookable wrapper

### DIFF
--- a/frontend/src/BrowseTab.tsx
+++ b/frontend/src/BrowseTab.tsx
@@ -4,10 +4,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   Group,
   Loader,
-  SegmentedControl,
   Stack,
   Text,
 } from '@mantine/core';
+import SegmentedControl from '@/elements/SegmentedControl.tsx';
 import { faArrowUp } from '@fortawesome/free-solid-svg-icons';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { axiosInstance } from '@/api/axios.ts';

--- a/frontend/src/ContentInstallerPage.tsx
+++ b/frontend/src/ContentInstallerPage.tsx
@@ -3,10 +3,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   Group,
   Loader,
-  SegmentedControl,
   Text,
   Title,
 } from '@mantine/core';
+import SegmentedControl from '@/elements/SegmentedControl.tsx';
 import Alert from '@/elements/Alert.tsx';
 import Badge from '@/elements/Badge.tsx';
 import Select from '@/elements/input/Select.tsx';

--- a/frontend/src/ModpacksTab.tsx
+++ b/frontend/src/ModpacksTab.tsx
@@ -4,10 +4,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   Group,
   Loader,
-  SegmentedControl,
   Stack,
   Text,
 } from '@mantine/core';
+import SegmentedControl from '@/elements/SegmentedControl.tsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Alert from '@/elements/Alert.tsx';
 import Badge from '@/elements/Badge.tsx';


### PR DESCRIPTION
## Summary

- Upstream commit [`0ce7d3a`](https://github.com/calagopus/panel/commit/0ce7d3a) added a hookable wrapper for `SegmentedControl` at `@/elements/SegmentedControl.tsx`
- Migrated all 3 files (`ModpacksTab`, `ContentInstallerPage`, `BrowseTab`) from raw `@mantine/core` import to the new wrapper
- Ensures theme compatibility and hook support

Closes #3