### PR TITLE
Migrate Group/Stack/Text/Title imports to hookable wrappers

### DIFF
--- a/frontend/src/AdminConfigPage.tsx
+++ b/frontend/src/AdminConfigPage.tsx
@@ -1,8 +1,12 @@
 import { faCheck, faKey } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Alert, Group, Loader, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Alert, Loader, TextInput } from '@mantine/core';
 import { useEffect, useState } from 'react';
 import Button from '@/elements/Button.tsx';
+import Group from '@/elements/Group.tsx';
+import Stack from '@/elements/Stack.tsx';
+import Text from '@/elements/Text.tsx';
+import Title from '@/elements/Title.tsx';
 
 export default function AdminConfigPage() {
   const [loading, setLoading] = useState(true);

--- a/frontend/src/BrowseTab.tsx
+++ b/frontend/src/BrowseTab.tsx
@@ -2,11 +2,8 @@ import { marked } from 'marked';
 import { faArrowDown, faCheck, faExternalLink, faRefresh, faSearch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  Group,
   Loader,
   SegmentedControl,
-  Stack,
-  Text,
 } from '@mantine/core';
 import { faArrowUp } from '@fortawesome/free-solid-svg-icons';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -15,8 +12,11 @@ import Alert from '@/elements/Alert.tsx';
 import Badge from '@/elements/Badge.tsx';
 import Button from '@/elements/Button.tsx';
 import Card from '@/elements/Card.tsx';
+import Group from '@/elements/Group.tsx';
 import { Modal } from '@/elements/modals/Modal.tsx';
 import Select from '@/elements/input/Select.tsx';
+import Stack from '@/elements/Stack.tsx';
+import Text from '@/elements/Text.tsx';
 import TextInput from '@/elements/input/TextInput.tsx';
 import { useToast } from '@/providers/ToastProvider.tsx';
 import { useServerStore } from '@/stores/server.ts';

--- a/frontend/src/ContentInstallerPage.tsx
+++ b/frontend/src/ContentInstallerPage.tsx
@@ -1,15 +1,15 @@
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  Group,
   Loader,
   SegmentedControl,
-  Text,
-  Title,
 } from '@mantine/core';
 import Alert from '@/elements/Alert.tsx';
 import Badge from '@/elements/Badge.tsx';
+import Group from '@/elements/Group.tsx';
 import Select from '@/elements/input/Select.tsx';
+import Text from '@/elements/Text.tsx';
+import Title from '@/elements/Title.tsx';
 import { useEffect, useState } from 'react';
 import ServerContentContainer from '@/elements/containers/ServerContentContainer.tsx';
 import { useServerStore } from '@/stores/server.ts';

--- a/frontend/src/ManageTab.tsx
+++ b/frontend/src/ManageTab.tsx
@@ -1,15 +1,13 @@
 import { faArrowUp, faExternalLink, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  Group,
-  Loader,
-  Text,
-} from '@mantine/core';
+import { Loader } from '@mantine/core';
 import { useCallback, useEffect, useState } from 'react';
 import { axiosInstance } from '@/api/axios.ts';
 import Alert from '@/elements/Alert.tsx';
 import Button from '@/elements/Button.tsx';
 import Card from '@/elements/Card.tsx';
+import Group from '@/elements/Group.tsx';
+import Text from '@/elements/Text.tsx';
 import ConfirmationModal from '@/elements/modals/ConfirmationModal.tsx';
 import { useToast } from '@/providers/ToastProvider.tsx';
 import { useServerStore } from '@/stores/server.ts';

--- a/frontend/src/ModpacksTab.tsx
+++ b/frontend/src/ModpacksTab.tsx
@@ -2,11 +2,8 @@ import { marked } from 'marked';
 import { faArrowDown, faCheck, faExclamationTriangle, faExternalLink, faSearch, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  Group,
   Loader,
   SegmentedControl,
-  Stack,
-  Text,
 } from '@mantine/core';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Alert from '@/elements/Alert.tsx';
@@ -14,9 +11,12 @@ import Badge from '@/elements/Badge.tsx';
 import Button from '@/elements/Button.tsx';
 import Card from '@/elements/Card.tsx';
 import Checkbox from '@/elements/input/Checkbox.tsx';
+import Group from '@/elements/Group.tsx';
 import { Modal } from '@/elements/modals/Modal.tsx';
 import Progress from '@/elements/Progress.tsx';
 import Select from '@/elements/input/Select.tsx';
+import Stack from '@/elements/Stack.tsx';
+import Text from '@/elements/Text.tsx';
 import TextInput from '@/elements/input/TextInput.tsx';
 import { useToast } from '@/providers/ToastProvider.tsx';
 import { useServerStore } from '@/stores/server.ts';


### PR DESCRIPTION
## Summary

- Migrates `Group` / `Stack` / `Text` / `Title` imports from `@mantine/core` to the new hookable wrappers at `@/elements/*` introduced in upstream calagopus/panel commit [`879f839`](https://github.com/calagopus/panel/commit/879f839)
- Ensures this extension's UI picks up theme overrides applied by `gg.ir77.themeeditor` (and any other theme/hooking extension) the same way the rest of the panel does

## Why

After `879f839`, the panel uses the hookable wrappers everywhere. Raw `@mantine/core` imports still compile, but they bypass the hooking system — so theme edits applied through the wrappers wouldn't reach our components, causing visual inconsistency when a theme extension is active.

Scope is limited to the wrapper components called out in the upstream issue. `SegmentedControl` is left alone here — it's covered by #4.

## Files changed

- `frontend/src/AdminConfigPage.tsx`
- `frontend/src/BrowseTab.tsx`
- `frontend/src/ContentInstallerPage.tsx`
- `frontend/src/ManageTab.tsx`
- `frontend/src/ModpacksTab.tsx`

Closes #5.

## Test plan

- [ ] Build the extension with `pnpm build` and confirm no type errors
- [ ] Load the extension in a panel with `gg.ir77.themeeditor` active and verify the layout components pick up theme overrides
- [ ] Sanity-check the affected pages render correctly without theme overrides too