### PR TITLE
Fix React error 185 on datapacks tab + wrong empty state text

### DIFF
--- a/frontend/src/ContentInstallerPage.tsx
+++ b/frontend/src/ContentInstallerPage.tsx
@@ -52,6 +52,9 @@ export default function ContentInstallerPage() {
       setAvailableTabs(tabs);
       setContentTab(tabs[0]);
       setSelectedWorld(result.worldDir);
+      const willShowModpacks = result.platform === 'mods' || result.platform === 'both'
+        || result.platform === 'unknown' || result.platform === 'vanilla';
+      if (!willShowModpacks) setMainTab('browse');
     }).finally(() => setDetecting(false));
   }, [server.uuid]);
 

--- a/frontend/src/ManageTab.tsx
+++ b/frontend/src/ManageTab.tsx
@@ -239,7 +239,7 @@ export default function ManageTab({ detection, contentType, installDir, refreshK
         <div className='ci-center'><Loader color='violet' size='lg' /></div>
       ) : items.length === 0 ? (
         <Text c='dimmed' ta='center' mt='xl'>
-          No {contentType === 'plugins' ? 'plugins' : 'mods'} installed.
+          No {contentType} installed.
           Browse and install some from the Browse tab!
         </Text>
       ) : (


### PR DESCRIPTION
## Summary

- Fixes #9

Two bugs fixed:

**1. React error 185 crash on datapacks tab**

When detection completed for a plugin-only server (PaperMC, Spigot, etc.), the Modpacks tab option was removed from the main `SegmentedControl` data array. If the user had clicked Modpacks during the detection loading phase, `mainTab` would remain as `'modpacks'` while the option was no longer present in `data`. Mantine's SegmentedControl attempting to call `onChange` while reconciling the removed value triggers React error 185 ("Cannot update a component while rendering a different component"), caught by the ErrorBoundary and displayed as a full-page crash.

Fix: when detection finishes for a server platform that doesn't support modpacks, reset `mainTab` to `'browse'` atomically in the same state batch.

**2. ManageTab shows "No mods installed." on datapacks tab**

The empty state message used `contentType === 'plugins' ? 'plugins' : 'mods'` which showed "No mods installed." for datapacks. Changed to use `contentType` directly.

## Test plan
- [ ] Open content installer on a PaperMC server, click Modpacks tab quickly while detection is still loading, confirm no crash after detection completes
- [ ] Switch to datapacks tab → Installed sub-tab with nothing installed → confirm it says "No datapacks installed."