### PR TITLE
Require panel >=1.1.0 in extension metadata

### DIFF
--- a/Metadata.toml
+++ b/Metadata.toml
@@ -1,3 +1,3 @@
 package_name = "gg.ir77.contentinstaller"
 name = "Content Installer"
-panel_version = ">=1.0.0"
+panel_version = ">=1.1.0"


### PR DESCRIPTION
## Summary

- Fixes #11
- Bumps `panel_version` in `Metadata.toml` from `>=1.0.0` to `>=1.1.0`

Panel 1.1.0 (calagopus/panel#147) added a hard gate in `shared/src/extensions/distr.rs` (`check_panel_version`, `MINIMUM_PANEL_VERSION = 1.1.0`): any extension whose `panel_version` requirement admits panel versions older than 1.1.0 is declined with an `AllowsOutdated` error. `>=1.1.0` satisfies both the outdated-range check and compatibility with the current panel version (exactly `1.1.0` on main).

The rest of the 1.1.x merge was audited against this extension (axios interceptor change, server store slice removals, shared package/registry changes, element changes, Rust shared crate moves) — no code changes needed. Details in #11.

## Test plan

- [ ] Package the extension and install it on a panel built from current `calagopus/panel` main (1.1.0) — upload should validate instead of being declined