### PR TITLE
Add CurseForge category filtering to browse search

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gg_ir77_contentinstaller"
 description = "Minecraft Plugin & Mod Installer Extension"
 authors = ["Regrave"]
-version = "2.3.0"
+version = "2.4.0"
 edition = { workspace = true }
 
 [dependencies]

--- a/backend/src/curseforge.rs
+++ b/backend/src/curseforge.rs
@@ -42,6 +42,8 @@ pub struct SearchParams {
     sort_field: Option<u32>,
     #[serde(rename = "sortOrder")]
     sort_order: Option<String>,
+    #[serde(rename = "categoryIds")]
+    category_ids: Option<String>,
     index: Option<u32>,
     #[serde(rename = "pageSize")]
     page_size: Option<u32>,
@@ -74,8 +76,74 @@ pub async fn search(
     if let Some(ref so) = params.sort_order {
         url.push_str(&format!("&sortOrder={so}"));
     }
+    if let Some(ref cids) = params.category_ids {
+        // Comma-separated ids from the frontend; CF wants a stringified array,
+        // e.g. categoryIds=[423,426]. Max 10 per CF docs.
+        let ids: Vec<u32> = cids
+            .split(',')
+            .map(|s| s.trim().parse::<u32>())
+            .collect::<Result<_, _>>()
+            .map_err(|_| err(StatusCode::BAD_REQUEST, "Invalid categoryIds"))?;
+        if ids.len() > 10 {
+            return Err(err(StatusCode::BAD_REQUEST, "At most 10 categoryIds allowed"));
+        }
+        if !ids.is_empty() {
+            let list = ids.iter().map(u32::to_string).collect::<Vec<_>>().join(",");
+            url.push_str(&format!("&categoryIds={}", urlencoding::encode(&format!("[{list}]"))));
+        }
+    }
     url.push_str(&format!("&index={}", params.index.unwrap_or(0)));
     url.push_str(&format!("&pageSize={}", params.page_size.unwrap_or(20)));
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .header("x-api-key", &api_key)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("CurseForge request failed: {e}")))?;
+
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("Failed to read response: {e}")))?;
+
+    if !status.is_success() {
+        return Err(err(
+            StatusCode::BAD_GATEWAY,
+            format!("CurseForge returned {status}: {body}"),
+        ));
+    }
+
+    Ok((
+        StatusCode::OK,
+        [("content-type", "application/json")],
+        body,
+    ))
+}
+
+// ---- Get categories ----
+
+#[derive(Deserialize)]
+pub struct CategoriesParams {
+    #[serde(rename = "classId")]
+    class_id: Option<u32>,
+}
+
+/// GET /content-installer/curseforge/categories
+pub async fn categories(
+    state: GetState,
+    _permissions: GetPermissionManager,
+    Query(params): Query<CategoriesParams>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let api_key = get_api_key(&state).await?;
+
+    let mut url = format!("{CF_BASE}/v1/categories?gameId={CF_MINECRAFT_GAME_ID}");
+    if let Some(cid) = params.class_id {
+        url.push_str(&format!("&classId={cid}"));
+    }
 
     let client = reqwest::Client::new();
     let resp = client

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -106,6 +106,10 @@ impl Extension for ExtensionStruct {
                         axum::routing::get(curseforge::status),
                     )
                     .route(
+                        "/content-installer/curseforge/categories",
+                        axum::routing::get(curseforge::categories),
+                    )
+                    .route(
                         "/content-installer/curseforge/description",
                         axum::routing::get(curseforge::description),
                     )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gg_content_installer",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/frontend/src/BrowseTab.tsx
+++ b/frontend/src/BrowseTab.tsx
@@ -28,10 +28,12 @@ import {
   checkCurseForgeStatus,
   formatDownloads as cfFormatDownloads,
   formatSize as cfFormatSize,
+  getCurseForgeCategories,
   getCurseForgeDescription,
   getCurseForgeFiles,
   releaseTypeLabel,
   searchCurseForge,
+  type CurseForgeCategory,
   type CurseForgeFile,
   type CurseForgeProject,
 } from './curseforge.ts';
@@ -94,8 +96,10 @@ export default function BrowseTab({ detection, contentType, installDir, onInstal
   const [filterVersion, setFilterVersion] = useState<string | null>(detection.mcVersion);
   const [filterLoader, setFilterLoader] = useState<string | null>(null);
   const [filterCategories, setFilterCategories] = useState<string[]>([]);
+  const [filterCfCategories, setFilterCfCategories] = useState<string[]>([]);
   const [versionOptionsList, setVersionOptionsList] = useState<string[]>([]);
   const [categoryOptionsList, setCategoryOptionsList] = useState<ModrinthCategoryTag[]>([]);
+  const [cfCategoryOptionsList, setCfCategoryOptionsList] = useState<CurseForgeCategory[]>([]);
 
   // Detail modal
   const [selectedProject, setSelectedProject] = useState<DisplayProject | null>(null);
@@ -130,6 +134,15 @@ export default function BrowseTab({ detection, contentType, installDir, onInstal
     getCategoryTags().then(setCategoryOptionsList).catch(() => {});
   }, [server.uuid]);
 
+  // CF categories are per-class, so reload and reset the selection when the class changes (#14)
+  useEffect(() => {
+    setFilterCfCategories([]);
+    if (!cfAvailable) return;
+    getCurseForgeCategories(server.uuid, cfClassId)
+      .then(setCfCategoryOptionsList)
+      .catch(() => setCfCategoryOptionsList([]));
+  }, [server.uuid, cfAvailable, cfClassId]);
+
   // Effective loader set: null = server default (smart compat expansion),
   // 'any' = no loader filter, anything else = exactly that loader. Memoized —
   // inline arrays here would change identity every render and loop the search effect.
@@ -154,6 +167,13 @@ export default function BrowseTab({ detection, contentType, installDir, onInstal
     const pool = exact.length > 0 ? exact : categoryOptionsList.filter((c) => c.project_type === 'mod');
     return [...new Set(pool.map((c) => c.name))].sort();
   }, [categoryOptionsList, contentType]);
+  const cfCategoryFilterOptions = useMemo(
+    () => cfCategoryOptionsList
+      .filter((c) => !c.isClass)
+      .map((c) => ({ value: String(c.id), label: c.name }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [cfCategoryOptionsList],
+  );
 
   // Modrinth search
   const doModrinthSearch = useCallback(async (q: string, sort: string, offset: number) => {
@@ -198,6 +218,7 @@ export default function BrowseTab({ detection, contentType, installDir, onInstal
       modLoaderType: effCfLoader > 0 ? effCfLoader : undefined,
       sortField: sortMap[sort] ?? 1,
       sortOrder: 'desc',
+      categoryIds: filterCfCategories.length > 0 ? filterCfCategories.map(Number) : undefined,
       index: offset,
       pageSize: 20,
     });
@@ -213,7 +234,7 @@ export default function BrowseTab({ detection, contentType, installDir, onInstal
       curseforgeProject: p,
     }));
     return { items, total: res.pagination.totalCount };
-  }, [server.uuid, cfClassId, filterVersion, filterLoader, cfModLoaderType]);
+  }, [server.uuid, cfClassId, filterVersion, filterLoader, filterCfCategories, cfModLoaderType]);
 
   const doSearch = useCallback(async (q: string, sort: string, offset: number) => {
     setLoading(true);
@@ -499,12 +520,24 @@ export default function BrowseTab({ detection, contentType, installDir, onInstal
           size='xs'
           w={130}
         />
-        {source === 'modrinth' && (
+        {source === 'modrinth' ? (
           <MultiSelect
             placeholder={filterCategories.length === 0 ? 'Categories' : undefined}
             data={categoryFilterOptions}
             value={filterCategories}
             onChange={setFilterCategories}
+            clearable
+            searchable
+            size='xs'
+            w={260}
+          />
+        ) : cfCategoryFilterOptions.length > 0 && (
+          <MultiSelect
+            placeholder={filterCfCategories.length === 0 ? 'Categories' : undefined}
+            data={cfCategoryFilterOptions}
+            value={filterCfCategories}
+            onChange={setFilterCfCategories}
+            maxValues={10}
             clearable
             searchable
             size='xs'

--- a/frontend/src/curseforge.ts
+++ b/frontend/src/curseforge.ts
@@ -50,6 +50,15 @@ export interface CurseForgeFilesResponse {
   };
 }
 
+export interface CurseForgeCategory {
+  id: number;
+  name: string;
+  slug: string;
+  classId: number | null;
+  parentCategoryId: number | null;
+  isClass: boolean | null;
+}
+
 // ---- CurseForge class IDs ----
 export const CF_CLASS_MODS = 6;
 export const CF_CLASS_PLUGINS = 5;
@@ -75,6 +84,7 @@ export async function searchCurseForge(serverUuid: string, opts: {
   modLoaderType?: number;
   sortField?: number;
   sortOrder?: string;
+  categoryIds?: number[];
   index?: number;
   pageSize?: number;
 }): Promise<CurseForgeSearchResponse> {
@@ -88,6 +98,9 @@ export async function searchCurseForge(serverUuid: string, opts: {
   }
   if (opts.sortField) params.set('sortField', String(opts.sortField));
   if (opts.sortOrder) params.set('sortOrder', opts.sortOrder);
+  if (opts.categoryIds && opts.categoryIds.length > 0) {
+    params.set('categoryIds', opts.categoryIds.join(','));
+  }
   params.set('index', String(opts.index ?? 0));
   params.set('pageSize', String(opts.pageSize ?? 20));
 
@@ -125,6 +138,15 @@ export async function getCurseForgeDescription(serverUuid: string, modId: number
   if (!res.ok) return '';
   const data = await res.json();
   return data.data ?? '';
+}
+
+export async function getCurseForgeCategories(serverUuid: string, classId: number): Promise<CurseForgeCategory[]> {
+  const baseUrl = `/api/client/servers/${serverUuid}/content-installer/curseforge`;
+  const params = new URLSearchParams({ classId: String(classId) });
+  const res = await fetch(`${baseUrl}/categories?${params}`);
+  if (!res.ok) throw new Error(`CurseForge categories failed: ${res.status}`);
+  const data = await res.json();
+  return data.data ?? [];
 }
 
 export async function checkCurseForgeStatus(serverUuid: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Search proxy accepts a `categoryIds` query param (comma-separated ids, validated server-side as u32, max 10 per CF docs) and forwards it to `/v1/mods/search` as the stringified array format CF expects — this was the missing pass-through from #14
- New proxied endpoint `GET /content-installer/curseforge/categories` wraps CF `/v1/categories?gameId=432&classId=…` so the frontend can load the per-class category taxonomy
- Browse tab now shows CurseForge's own categories in the filter row when CF is the selected source (CF category ids don't map to Modrinth tag names, so each source keeps its own selection); selection resets when the content type changes since CF categories are per-class
- Bump to 2.4.0

## Notes
- CF's `categoryIds` docs don't specify AND vs OR semantics across multiple ids — Modrinth-side filtering is strict AND, so multi-category results may differ between sources
- The category MultiSelect caps at 10 selections to match the API limit

## Verification
- `cargo check -p gg_ir77_contentinstaller` inside a panel 1.1.0 workspace checkout: clean (2 pre-existing warnings in modpack code, untouched)
- Panel frontend `tsc`: clean with the extension mounted at `frontend/extensions/`
- Biome: no new violations vs main on the touched files

Closes #14