### PR TITLE
Fix filter state persisting across content-type tabs (#20)

### DIFF
--- a/frontend/src/BrowseTab.tsx
+++ b/frontend/src/BrowseTab.tsx
@@ -143,6 +143,15 @@ export default function BrowseTab({ detection, contentType, installDir, onInstal
       .catch(() => setCfCategoryOptionsList([]));
   }, [server.uuid, cfAvailable, cfClassId]);
 
+  // Reset content-type-specific filters when switching tabs (#20). The loader
+  // filter is hidden on the datapacks tab, so a stale 'paper' or 'fabric' value
+  // would silently poison every subsequent search. Modrinth categories are also
+  // scoped per project type — plugin categories don't exist for datapacks etc.
+  useEffect(() => {
+    setFilterLoader(null);
+    setFilterCategories([]);
+  }, [contentType]);
+
   // Effective loader set: null = server default (smart compat expansion),
   // 'any' = no loader filter, anything else = exactly that loader. Memoized —
   // inline arrays here would change identity every render and loop the search effect.


### PR DESCRIPTION
Fixes #20.

## Problem

Reported by @XCraftTM: filtering by Server Jar type on the Plugins tab and then switching to Datapacks kept the loader filter set. Because the datapacks tab hides the loader dropdown entirely, the user could not clear it, and every search silently returned zero results.

Same trap for Modrinth categories — category tags are scoped per project type, so a plugin category doesn't match mods/datapacks.

## Root cause

`ContentInstallerPage` renders `<BrowseTab contentType={...} />` without a `key`, so React keeps the same `BrowseTab` instance across tab switches. `filterLoader` and `filterCategories` state survive the switch even though they're no longer valid.

## Fix

New `useEffect` in `BrowseTab` that resets both filters when `contentType` changes:

```tsx
useEffect(() => {
  setFilterLoader(null);
  setFilterCategories([]);
}, [contentType]);
```

`filterVersion` intentionally left alone since Minecraft versions apply across all content types.

## Test plan
- [ ] Plugins tab: pick 'paper' loader, search returns Paper plugins
- [ ] Switch to Datapacks: loader filter cleared, results populate normally
- [ ] Switch back to Plugins: no stale filter carried over
- [ ] Mods tab: pick a Modrinth category, switch to Plugins, category cleared
- [ ] Version filter survives tab switches (unchanged behavior)