### PR TITLE
fix: report bad CurseForge key as 503 not 502

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gg_ir77_contentinstaller"
 description = "Minecraft Plugin & Mod Installer Extension"
 authors = ["Regrave"]
-version = "2.4.1"
+version = "2.4.2"
 edition = { workspace = true }
 
 [dependencies]

--- a/backend/src/curseforge.rs
+++ b/backend/src/curseforge.rs
@@ -26,6 +26,50 @@ async fn get_api_key(state: &GetState) -> Result<String, (StatusCode, String)> {
     Ok(ext.curseforge_api_key.to_string())
 }
 
+/// Authenticated GET against the CurseForge API, returning the raw response body.
+///
+/// Upstream 401/403 means the configured key is wrong — a user-fixable setting, not a
+/// gateway failure — so it does not collapse into a 502 the way it used to (#22). 502 is
+/// kept for genuine transport errors so "bad gateway" still means "could not reach CurseForge".
+async fn cf_get(url: &str, api_key: &str) -> Result<String, (StatusCode, String)> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(url)
+        .header("x-api-key", api_key)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("CurseForge request failed: {e}")))?;
+
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("Failed to read response: {e}")))?;
+
+    if status.is_success() {
+        return Ok(body);
+    }
+
+    Err(match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => err(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "CurseForge rejected the API key. Check it under Admin -> Content Installer. \
+             Keys look like `$2a$10$...` and are silently truncated by unquoted shell, \
+             .env or compose files, which eats the `$2a` and `$10` as variables."
+                .to_string(),
+        ),
+        StatusCode::TOO_MANY_REQUESTS => err(
+            StatusCode::TOO_MANY_REQUESTS,
+            "CurseForge rate limit reached. Try again in a moment.".to_string(),
+        ),
+        _ => err(
+            StatusCode::BAD_GATEWAY,
+            format!("CurseForge returned {status}: {body}"),
+        ),
+    })
+}
+
 // ---- Search ----
 
 #[derive(Deserialize)]
@@ -95,27 +139,7 @@ pub async fn search(
     url.push_str(&format!("&index={}", params.index.unwrap_or(0)));
     url.push_str(&format!("&pageSize={}", params.page_size.unwrap_or(20)));
 
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(&url)
-        .header("x-api-key", &api_key)
-        .header("Accept", "application/json")
-        .send()
-        .await
-        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("CurseForge request failed: {e}")))?;
-
-    let status = resp.status();
-    let body = resp
-        .text()
-        .await
-        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("Failed to read response: {e}")))?;
-
-    if !status.is_success() {
-        return Err(err(
-            StatusCode::BAD_GATEWAY,
-            format!("CurseForge returned {status}: {body}"),
-        ));
-    }
+    let body = cf_get(&url, &api_key).await?;
 
     Ok((
         StatusCode::OK,
@@ -145,27 +169,7 @@ pub async fn categories(
         url.push_str(&format!("&classId={cid}"));
     }
 
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(&url)
-        .header("x-api-key", &api_key)
-        .header("Accept", "application/json")
-        .send()
-        .await
-        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("CurseForge request failed: {e}")))?;
-
-    let status = resp.status();
-    let body = resp
-        .text()
-        .await
-        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("Failed to read response: {e}")))?;
-
-    if !status.is_success() {
-        return Err(err(
-            StatusCode::BAD_GATEWAY,
-            format!("CurseForge returned {status}: {body}"),
-        ));
-    }
+    let body = cf_get(&url, &api_key).await?;
 
     Ok((
         StatusCode::OK,
@@ -207,27 +211,7 @@ pub async fn files(
     url.push_str(&format!("index={}", params.index.unwrap_or(0)));
     url.push_str(&format!("&pageSize={}", params.page_size.unwrap_or(20)));
 
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(&url)
-        .header("x-api-key", &api_key)
-        .header("Accept", "application/json")
-        .send()
-        .await
-        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("CurseForge request failed: {e}")))?;
-
-    let status = resp.status();
-    let body = resp
-        .text()
-        .await
-        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("Failed to read response: {e}")))?;
-
-    if !status.is_success() {
-        return Err(err(
-            StatusCode::BAD_GATEWAY,
-            format!("CurseForge returned {status}: {body}"),
-        ));
-    }
+    let body = cf_get(&url, &api_key).await?;
 
     Ok((
         StatusCode::OK,
@@ -254,27 +238,7 @@ pub async fn description(
 
     let url = format!("{CF_BASE}/v1/mods/{}/description", params.mod_id);
 
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(&url)
-        .header("x-api-key", &api_key)
-        .header("Accept", "application/json")
-        .send()
-        .await
-        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("CurseForge request failed: {e}")))?;
-
-    let status = resp.status();
-    let body = resp
-        .text()
-        .await
-        .map_err(|e| err(StatusCode::BAD_GATEWAY, format!("Failed to read response: {e}")))?;
-
-    if !status.is_success() {
-        return Err(err(
-            StatusCode::BAD_GATEWAY,
-            format!("CurseForge returned {status}: {body}"),
-        ));
-    }
+    let body = cf_get(&url, &api_key).await?;
 
     Ok((
         StatusCode::OK,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -176,9 +176,14 @@ async fn admin_get_settings(
             "*".repeat(key.len())
         }
     };
+    // CurseForge keys are bcrypt-shaped (`$2a$10$...`). Anything that routes the key
+    // through an unquoted shell, .env or compose file eats `$2a` and `$10` as variable
+    // expansions and stores a silently truncated key, which CurseForge then rejects (#22).
+    let malformed = !ext.curseforge_api_key.is_empty() && !ext.curseforge_api_key.starts_with("$2a$");
     Ok(axum::Json(serde_json::json!({
         "curseforge_configured": !ext.curseforge_api_key.is_empty(),
         "curseforge_api_key_masked": masked,
+        "curseforge_api_key_malformed": malformed,
     })))
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gg_content_installer",
   "private": true,
-  "version": "2.4.1",
+  "version": "2.4.2",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Closes #22. Reported by Elvin on v2.4.1.

## Problem

`curseforge.rs` mapped *every* CurseForge failure to `BAD_GATEWAY`, including CurseForge cleanly answering 403. A wrong API key therefore surfaced as a bad gateway, which reads as a network/egress fault.

Reproduced exactly — invalid key gave `HTTP 502`, body **72 bytes**:
```
CurseForge returned 403 Forbidden: Forbidden: API Key missing or invalid
```
matching the `size 72 B` in the reporter's devtools screenshot byte-for-byte.

## Changes

- Four identical request blocks folded into one `cf_get` helper.
- CF `401`/`403` -> `503` with a message naming the fix.
- CF `429` -> `429`. Everything else stays `502`, which now genuinely means "couldn't reach CurseForge".
- Admin settings expose `curseforge_api_key_malformed` — true when a stored key doesn't start with `$2a$`.

## Why the malformed flag

CF keys are bcrypt-shaped (`$2a$10$...`). Unquoted shell/.env/compose eats `$2a` and `$10` as expansions and stores a truncated key. Hit this live while debugging — sourcing our own `curseforge.env` turned a 60-char key into a 54-char one silently.

## Verification

On the 1.1.0 testbed against the real CurseForge API:

| state | before | after |
|---|---|---|
| valid key | 200, totalCount 1599 | 200, totalCount 1599 |
| rejected key | **502**, 72 B, "bad gateway" | **503**, 217 B, names the fix |
| mangled key in admin | not surfaced | `malformed: true` |
| empty key | 503 "not configured" | unchanged |

Category AND-semantics still hold (`434,410` -> 1599). Zero errors in the panel log.